### PR TITLE
Wrong vendor prefix for IE, different syntaxes for transform: matrix()

### DIFF
--- a/lib/css_hooks.js
+++ b/lib/css_hooks.js
@@ -13,12 +13,14 @@ require('TransformJS/sylvester');
     return;
   }
   
+  var translationUnit = 'px'
+  
   var prop = "transform",
       vendorProp, supportedProp, supports3d, supports2d, supportsFilter,
       
       // capitalize first character of the prop to test vendor prefix
       capProp = prop.charAt(0).toUpperCase() + prop.slice(1),
-      prefixes = [ "Moz", "Webkit", "O", "MS" ],
+      prefixes = [ "Moz", "Webkit", "O", "ms" ],
       div = document.createElement( "div" );
 
   if ( prop in div.style ) {
@@ -34,7 +36,10 @@ require('TransformJS/sylvester');
       vendorProp = prefixes[i] + capProp;
 
       if ( vendorProp in div.style ) {
-        supportedProp = vendorProp;    
+        supportedProp = vendorProp;
+        if (prefixes[i] == 'ms') {
+            translationUnit = ''
+        }
         if((prefixes[i] + 'Perspective') in div.style) {
           supports3d = true;
         }
@@ -240,7 +245,7 @@ require('TransformJS/sylvester');
         s  = "matrix(";
           s += tM.e(1,1).toFixed(10) + "," + tM.e(1,2).toFixed(10) + ",";
           s += tM.e(2,1).toFixed(10) + "," + tM.e(2,2).toFixed(10) + ",";
-          s += tM.e(3,1).toFixed(10) + "px," + tM.e(3,2).toFixed(10)+'px';
+          s += tM.e(3,1).toFixed(10) + translationUnit + "," + tM.e(3,2).toFixed(10) + translationUnit;
         s += ")";        
       }
       else if (supportsFilter) {


### PR DESCRIPTION
Hey guys, great work on the library!

One issue I'm having right now is that it currently uses the MS vendor prefix for IE, but the one used by Microsoft is actually ms (lowercased). That makes the transforms in IE9 fallback to filter:DXTransform, which is super slow and buggy.

Another issue I'm having is that there are two different syntaxes for the transform property. The one proposed by mozilla accepts units on the tx and ty components of the matrix, while the one proposed by Webkit does not. Strangely enough, Webkit seems to accept mozilla syntax just fine now, but IE only seems to accept the Webkit syntax. I made some changes on the library to reflect this, and I'm issuing a pull request.
