### PR TITLE
Remove require "sproutcore" from Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,4 @@
 require "bundler/setup"
-require "sproutcore"
 require "erb"
 require "uglifier"
 


### PR DESCRIPTION
It does not seem to be needed, and stops me from running rake
since it's not listed in Gemfile.
