### PR TITLE
Fix for transformX and transformY in IE.

### DIFF
--- a/lib/css_hooks.js
+++ b/lib/css_hooks.js
@@ -13,7 +13,7 @@ require('TransformJS/sylvester');
     return;
   }
 
-  var translationUnit = ''
+  var translationUnit = '';
 
   var prop = "transform",
       vendorProp, supportedProp, supports3d, supports2d, supportsFilter,
@@ -38,7 +38,7 @@ require('TransformJS/sylvester');
       if ( vendorProp in div.style ) {
         supportedProp = vendorProp;
         if (prefixes[i] === 'Moz') {
-            translationUnit = 'px'
+            translationUnit = 'px';
         }
         if((prefixes[i] + 'Perspective') in div.style) {
           supports3d = true;
@@ -230,7 +230,7 @@ require('TransformJS/sylvester');
       }
 
       for (var name in properties) {
-        tM = tM.x(properties[name].matrix(transforms[name] || properties[name].defaultValue))
+        tM = tM.x(properties[name].matrix(transforms[name] || properties[name].defaultValue));
       }
 
       if (supports3d) {
@@ -263,7 +263,7 @@ require('TransformJS/sylvester');
       }
 
       elem.style[transformProperty] = s;
-  }
+  };
 
   var hookFor = function(name) {
 
@@ -289,15 +289,15 @@ require('TransformJS/sylvester');
         if (typeof propInfo.apply === 'function') {
           transforms[name] = propInfo.apply(transforms[name] || propInfo.defaultValue, value);
         } else {
-          transforms[name] = value
+          transforms[name] = value;
         }
 
         $(elem).data('transforms',transforms);
 
         applyMatrix(elem);
       }
-    }
-  }
+    };
+  };
 
   if (transformProperty) {
     for (var name in properties) {

--- a/lib/css_hooks.js
+++ b/lib/css_hooks.js
@@ -258,8 +258,8 @@ require('TransformJS/sylvester');
             s += "SizingMethod='auto expand'";
           s += ")";
           
-        elem.style.top = tM.e(3,1);
-        elem.style.left = tM.e(3,2);
+        elem.style.top = tM.e(3,1) + 'px';
+        elem.style.left = tM.e(3,2) + 'px';
       }
 
       elem.style[transformProperty] = s;

--- a/lib/css_hooks.js
+++ b/lib/css_hooks.js
@@ -1,23 +1,23 @@
 // ==========================================================================
-// Project:  TransformJS        
+// Project:  TransformJS
 // Copyright: ©2011 Strobe Inc.
 // License:   Licensed under MIT license (see license.js)
 // ==========================================================================
 
 require('TransformJS/sylvester');
-  
+
 (function($) {
 
   if ( !$.cssHooks ) {
     throw("jQuery 1.4.3+ is needed for this plugin to work");
     return;
   }
-  
+
   var translationUnit = ''
-  
+
   var prop = "transform",
       vendorProp, supportedProp, supports3d, supports2d, supportsFilter,
-      
+
       // capitalize first character of the prop to test vendor prefix
       capProp = prop.charAt(0).toUpperCase() + prop.slice(1),
       prefixes = [ "Moz", "Webkit", "O", "ms" ],
@@ -28,7 +28,7 @@ require('TransformJS/sylvester');
     // browser supports standard CSS property name
     supportedProp = prop;
     supports3d = div.style.perspective !== undefined;
-  } 
+  }
   else {
 
     // otherwise test support for vendor-prefixed property names
@@ -50,7 +50,7 @@ require('TransformJS/sylvester');
       }
     }
   }
-  
+
   if (!supportedProp) {
     supportsFilter = ('filter' in div.style);
     supportedProp = 'filter';
@@ -60,10 +60,10 @@ require('TransformJS/sylvester');
 
   // avoid memory leak in IE
   div = null;
-  
+
   // add property to $.support so it can be accessed elsewhere
   $.support[ prop ] = supportedProp;
-  
+
   var transformProperty = supportedProp;
 
   var properties = {
@@ -76,14 +76,14 @@ require('TransformJS/sylvester');
             [0,Math.cos(a), Math.sin(-a), 0],
             [0,Math.sin(a), Math.cos( a), 0],
             [0,0,0,1]
-          ]);          
+          ]);
         }
         else {
           return $M([
             [1, 0,0],
             [0, 1,0],
             [0,0,1]
-          ]);               
+          ]);
         }
       }
     },
@@ -103,7 +103,7 @@ require('TransformJS/sylvester');
             [1, 0,0],
             [0, 1,0],
             [0,0,1]
-          ]);               
+          ]);
         }
       }
     },
@@ -123,7 +123,7 @@ require('TransformJS/sylvester');
             [Math.cos(c), Math.sin(-c),0],
             [Math.sin(c), Math.cos( c),0],
             [0,0,1]
-          ]);          
+          ]);
         }
       }
     },
@@ -143,7 +143,7 @@ require('TransformJS/sylvester');
             [s, 0,0],
             [0, s,0],
             [0,0,1]
-          ]);               
+          ]);
         }
       }
     },
@@ -163,7 +163,7 @@ require('TransformJS/sylvester');
             [1, 0,0],
             [0, 1,0],
             [tx,0,1]
-          ]);               
+          ]);
         }
       }
     },
@@ -183,7 +183,7 @@ require('TransformJS/sylvester');
             [1, 0,0],
             [0, 1,0],
             [0,ty,1]
-          ]);               
+          ]);
         }
       }
     },
@@ -203,16 +203,16 @@ require('TransformJS/sylvester');
             [1, 0,0],
             [0, 1,0],
             [0,0,1]
-          ]);               
+          ]);
         }
       }
     }
   };
-  
+
   var applyMatrix = function(elem) {
       var transforms = $(elem).data('transforms');
       var tM;
-      
+
       if (supports3d) {
         tM = $M([
           [1,0,0,0],
@@ -232,45 +232,45 @@ require('TransformJS/sylvester');
       for (var name in properties) {
         tM = tM.x(properties[name].matrix(transforms[name] || properties[name].defaultValue))
       }
-      
+
       if (supports3d) {
         s  = "matrix3d(";
           s += tM.e(1,1).toFixed(10) + "," + tM.e(1,2).toFixed(10) + "," + tM.e(1,3).toFixed(10) + "," + tM.e(1,4).toFixed(10) + ",";
           s += tM.e(2,1).toFixed(10) + "," + tM.e(2,2).toFixed(10) + "," + tM.e(2,3).toFixed(10) + "," + tM.e(2,4).toFixed(10) + ",";
           s += tM.e(3,1).toFixed(10) + "," + tM.e(3,2).toFixed(10) + "," + tM.e(3,3).toFixed(10) + "," + tM.e(3,4).toFixed(10) + ",";
           s += tM.e(4,1).toFixed(10) + "," + tM.e(4,2).toFixed(10) + "," + tM.e(4,3).toFixed(10) + "," + tM.e(4,4).toFixed(10);
-        s += ")";        
+        s += ")";
       }
       else if (supports2d) {
         s  = "matrix(";
           s += tM.e(1,1).toFixed(10) + "," + tM.e(1,2).toFixed(10) + ",";
           s += tM.e(2,1).toFixed(10) + "," + tM.e(2,2).toFixed(10) + ",";
           s += tM.e(3,1).toFixed(10) + translationUnit + "," + tM.e(3,2).toFixed(10) + translationUnit;
-        s += ")";        
+        s += ")";
       }
       else if (supportsFilter) {
         s = "progid:DXImageTransform.Microsoft.";
-			 	  s += "Matrix(";
-            s += "M11="+tM.e(1,1).toFixed(10) + ",";
-            s += "M12="+tM.e(1,2).toFixed(10) + ",";
-            s += "M21="+tM.e(2,1).toFixed(10) + ",";
-            s += "M22="+tM.e(2,2).toFixed(10) + ",";
-            s += "SizingMethod='auto expand'";
-          s += ")";
-          
+        s += "Matrix(";
+        s += "M11="+tM.e(1,1).toFixed(10) + ",";
+        s += "M12="+tM.e(1,2).toFixed(10) + ",";
+        s += "M21="+tM.e(2,1).toFixed(10) + ",";
+        s += "M22="+tM.e(2,2).toFixed(10) + ",";
+        s += "SizingMethod='auto expand'";
+        s += ")";
+
         elem.style.top = tM.e(3,1) + 'px';
         elem.style.left = tM.e(3,2) + 'px';
       }
 
       elem.style[transformProperty] = s;
   }
-  
+
   var hookFor = function(name) {
-    
+
     $.fx.step[name] = function(fx){
       $.cssHooks[name].set( fx.elem, fx.now + fx.unit );
     };
-    
+
     return {
       get: function( elem, computed, extra ) {
         var transforms = $(elem).data('transforms');
@@ -278,7 +278,7 @@ require('TransformJS/sylvester');
           transforms = {};
           $(elem).data('transforms',transforms);
         }
-        
+
         return transforms[name] || properties[name].defaultValue;
       },
       set: function( elem, value) {
@@ -291,9 +291,9 @@ require('TransformJS/sylvester');
         } else {
           transforms[name] = value
         }
-        
+
         $(elem).data('transforms',transforms);
-        
+
         applyMatrix(elem);
       }
     }
@@ -303,7 +303,7 @@ require('TransformJS/sylvester');
     for (var name in properties) {
       $.cssHooks[name] = hookFor(name);
       $.cssNumber[name] = true;
-    } 
+    }
   }
 
 })(jQuery);

--- a/lib/css_hooks.js
+++ b/lib/css_hooks.js
@@ -10,7 +10,6 @@ require('TransformJS/sylvester');
 
   if ( !$.cssHooks ) {
     throw("jQuery 1.4.3+ is needed for this plugin to work");
-    return;
   }
 
   var translationUnit = '';


### PR DESCRIPTION
Because $.cssNumber is set to true for all properties a unit (px) must be
set when manually applying the 'top' and 'left' properties.
